### PR TITLE
Add a new usage of HashSet

### DIFF
--- a/src/main/java/demo/customqueries/HashCollections.java
+++ b/src/main/java/demo/customqueries/HashCollections.java
@@ -17,6 +17,9 @@ public class HashCollections {
         // We want to highlight this undesirable use of HashSet
         exampleSet = new HashSet<String>();
 
+        // We add another undesirable usage in this PR
+        exampleSet = new HashSet<String>();
+
         // Whereas LinkedHashSet is the preferred alternative
         exampleSet = new LinkedHashSet<String>();
 


### PR DESCRIPTION
This PR adds a new usage of `java.util.HashSet`, which should be highlighted by LGTM automated code review.